### PR TITLE
fix: remove handleRouteChanged property in config of functional compo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ const MyComponent = () => {
 
 const onRoutedChangedConfig = {
   mounted: true,
-  onlyPathname: false,
-  handleRouteChanged: MyComponent.handleRouteChanged
+  onlyPathname: false
 }
 
 export default onRouteChangedHOC(MyComponent, onRoutedChangedConfig)
@@ -69,4 +68,3 @@ The `location` object has the following attributes:
 | -------------- | --------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `mounted`      | `boolean` | `false` | If `true`, the `handleRouteChanged` method of the wrappedComponent will be called with `(null, currentLocation)`when the component is mounted.                                                                                          |
 | `onlyPathname` | `boolean` | `true`  | If `true`, the `handleRouteChanged` method will only be called when the `pathname` of the location has been changed. If `false`, the changes of `search` or `hash` of the `location` will also trigger the `handleRouteChanged` method. |
-| `handleRouteChanged` | `function` |   | `handleRouteChanged` method is required when the DecoratedComponent is a functional component |

--- a/es/index.js
+++ b/es/index.js
@@ -46,8 +46,8 @@ var onRouteChangedHOC = function onRouteChangedHOC(DecoratedComponent) {
     var __getHandleRouteChangedFunc = function __getHandleRouteChangedFunc() {
       var handleRouteChanged;
 
-      if (!isReactComponent && typeof config.handleRouteChanged === 'function') {
-        handleRouteChanged = config.handleRouteChanged;
+      if (!isReactComponent && typeof DecoratedComponent.handleRouteChanged === 'function') {
+        handleRouteChanged = DecoratedComponent.handleRouteChanged;
       }
 
       if (isReactComponent && typeof instanceRef.current.handleRouteChanged === 'function') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-onroutechanged",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An onRouteChanged wrapper for React components",
   "main": "es/index.js",
   "types": "types/index",

--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,8 @@ const onRouteChangedHOC = (DecoratedComponent, config = { mounted: false, onlyPa
     const __getHandleRouteChangedFunc = () => {
       let handleRouteChanged
 
-      if (!isReactComponent && typeof config.handleRouteChanged === 'function') {
-        handleRouteChanged = config.handleRouteChanged
+      if (!isReactComponent && typeof DecoratedComponent.handleRouteChanged === 'function') {
+        handleRouteChanged = DecoratedComponent.handleRouteChanged
       }
 
       if (isReactComponent && typeof instanceRef.current.handleRouteChanged === 'function') {


### PR DESCRIPTION
When pass config.handleRouteChanged to onRouteChangedHOC, DecoratedComponent.handleRouteChanged hasn't been assign value.